### PR TITLE
fix: update pricing section to show single 'Try Now' option

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,37 +88,17 @@
         <div class="container">
             <h2>Simple, Transparent Pricing</h2>
             <div class="pricing-cards">
-                <div class="pricing-card">
-                    <h3>Free</h3>
-                    <div class="price">$0<span>/month</span></div>
-                    <ul>
-                        <li>Basic handicap calculation</li>
-                        <li>Up to 20 rounds</li>
-                        <li>Mobile access</li>
-                    </ul>
-                    <button class="btn-outline">Get Started</button>
-                </div>
                 <div class="pricing-card featured">
-                    <h3>Pro</h3>
-                    <div class="price">$9<span>/month</span></div>
+                    <h3>Golf Handicap Manager</h3>
+                    <div class="price">Free<span> to start</span></div>
                     <ul>
+                        <li>Automatic handicap calculation</li>
                         <li>Unlimited rounds</li>
-                        <li>Advanced analytics</li>
-                        <li>Course database access</li>
-                        <li>Export data</li>
+                        <li>Mobile access</li>
+                        <li>Progress tracking</li>
+                        <li>Cloud sync</li>
                     </ul>
-                    <button class="btn-primary">Start Free Trial</button>
-                </div>
-                <div class="pricing-card">
-                    <h3>Club</h3>
-                    <div class="price">$29<span>/month</span></div>
-                    <ul>
-                        <li>Everything in Pro</li>
-                        <li>Up to 50 members</li>
-                        <li>Club tournaments</li>
-                        <li>Priority support</li>
-                    </ul>
-                    <button class="btn-outline">Contact Sales</button>
+                    <button class="btn-primary">Try Now</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Replaced multiple pricing tiers with a single option featuring a "Try Now" button.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)